### PR TITLE
Updated status badge in README.md file

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,6 @@ This repository has a pre-commit hook that will attempt to correct any linting a
 issues. If there are any files that still contain lint after running the pre-commit hook, the commit
 will fail, and you will have to manually correct the issues.
 
-[![Greetings](https://github.com/aaronshivers/snapit-hacktoberfest/actions/workflows/greetings.yml/badge.svg)](https://github.com/aaronshivers/snapit-hacktoberfest/actions/workflows/greetings.yml)
+[![Greetings](https://github.com/aaron-org/snapit-hacktoberfest/actions/workflows/greetings.yml/badge.svg)](https://github.com/aaron-org/snapit-hacktoberfest/actions/workflows/greetings.yml)
 
-[![CI Pipeline](https://github.com/aaronshivers/snapit-hacktoberfest/actions/workflows/ci-pipeline.yml/badge.svg?branch=andy-ci-pipeline-integration)](https://github.com/aaronshivers/snapit-hacktoberfest/actions/workflows/ci-pipeline.yml)
+[![CI Pipeline](https://github.com/aaron-org/snapit-hacktoberfest/actions/workflows/ci-pipeline.yml/badge.svg)](https://github.com/aaron-org/snapit-hacktoberfest/actions/workflows/ci-pipeline.yml)


### PR DESCRIPTION
Updated status badge in README.md file so that it will display for status reflect the status of the default branch - which should be main - rather than a hard coded branch

<!--
We appreciate the effort for this pull request but before that please make sure you read the contribution guidelines, then fill out the blanks below.

Please format the PR title appropriately based on the type of change:
  <type>[!]: <description>
Where <type> is one of: docs, chore, feat, fix, test.
Add a '!' after the type for breaking changes (e.g. feat!: new breaking feature).

**All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.**

Please enter each Issue number you are resolving in your PR after one of the following words [Fixes, Closes, Resolves]. This will auto-link these issues and close them when this PR is merged!
e.g.
Fixes #1
Closes #2
-->

# Fixes #

The "ci-pipeline" status badge shows whether that workflow is currently failing or passing. Assuming that you have permissions, clicking on the badge will also take you directly into the build view so you can see the pipelines and builds.

### Checklist
- [x] I acknowledge that all my contributions will be made under the project's license
- [x] I have made a material change to the repo (functionality, testing, spelling, grammar)
- [x] I have read the [Contribution Guidelines](https://github.com/aaronshivers/snapit-hacktoberfest/blob/main/CONTRIBUTING.md) and my PR follows them
- [x] I have titled the PR appropriately
- [x] I have updated my branch with the main branch
- [x] I have added the necessary documentation about the functionality in the appropriate .md file

If you have questions, please create a GitHub Issue in this repository.
